### PR TITLE
chore: update @utoo/pack-cli to 1.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@types/pidusage": "^2.0.5",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
-    "@utoo/pack-cli": "1.4.26",
+    "@utoo/pack-cli": "1.5.0",
     "@vitejs/plugin-react": "^6.0.3",
     "browserslist": "^4.28.6",
     "buffer": "^6.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,8 +81,8 @@ importers:
         specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.17)
       '@utoo/pack-cli':
-        specifier: 1.4.26
-        version: 1.4.26(postcss@8.5.19)
+        specifier: 1.5.0
+        version: 1.5.0(postcss@8.5.19)
       '@vitejs/plugin-react':
         specifier: ^6.0.3
         version: 6.0.3(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.46.0)(yaml@2.9.0))
@@ -4238,63 +4238,63 @@ packages:
     peerDependencies:
       react: '>= 16.8.0'
 
-  '@utoo/pack-cli@1.4.26':
-    resolution: {integrity: sha512-clYmRA412f1GzlO4UsewaK0AzBpHyt7W9yvb88qeuEHja44XZe8hUpwh9MLelqy6mYISBYhm2H+XBTKrnAOR0g==}
+  '@utoo/pack-cli@1.5.0':
+    resolution: {integrity: sha512-zoO89QUUaWpQvREDd4vuKTCZLlZyjjiV5BImJnMsLkzcosK0vOUZslxC1qqVyBYocBW+ktpRQgkJUlo3iBaktg==}
     engines: {node: '>= 20'}
     hasBin: true
 
-  '@utoo/pack-darwin-arm64@1.4.26':
-    resolution: {integrity: sha512-wPjHOT0R4jyzeLgtemyn4Fc2+nw60KNDOypy9YmNkr4vt0S0pzXNfLccf5Ij/UkaeQjzeoki6vuM+lU3R4HuYg==}
+  '@utoo/pack-darwin-arm64@1.5.0':
+    resolution: {integrity: sha512-bymMwDKlAJYRDN4aL8PV3cykB/82eKrpmqvgvJg0t1aAJ/7ym6BoAzuTAUV4DG9ZP5sSlyKRJTUbup/Iu2QWTQ==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [darwin]
 
-  '@utoo/pack-darwin-x64@1.4.26':
-    resolution: {integrity: sha512-ycI40AVkWQy6fSpDdYzZk1lIVBtHyA38zSu10ExNdN2mcJlFc3p4VKcfC3/PfrkkEZa5JscjhvFZTZgY4yUXgw==}
+  '@utoo/pack-darwin-x64@1.5.0':
+    resolution: {integrity: sha512-qH8/Y0cl47SMsQr6EcwsJPsjcB/ycBAeuDx4sdC5y8ZhYL5kJWNIzKENtPK7fWMCoFRcICMF+nK8ujvRWZll7Q==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [darwin]
 
-  '@utoo/pack-linux-arm64-gnu@1.4.26':
-    resolution: {integrity: sha512-D4soaMT7LthwlEpvc13K5RbB7SdgzvKhq7/kIqxorTmdaOQqn9ybDqEdubk7EJOvCZYJM3ET8m+Llqsc9cL9aA==}
+  '@utoo/pack-linux-arm64-gnu@1.5.0':
+    resolution: {integrity: sha512-06kznzqnv5yscFWJALr1KZQ6PsoNua/wkk3CygWFvS468lJM6eUDie3smSRkpbadnDkpWUGJMCGo0duYULmGng==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@utoo/pack-linux-arm64-musl@1.4.26':
-    resolution: {integrity: sha512-23zFIAINYpsBbwzNoxH4B/vBnp9ISKluKTI32Us1YcGh0QK1h49UMl77ECy9Ob1jinxpgMZFEDsZKdkkOeKH8g==}
+  '@utoo/pack-linux-arm64-musl@1.5.0':
+    resolution: {integrity: sha512-ENu7j6pwb/AIkPN0cgumbtlSAAhg5iZHh+3G7Fm3ZR0OIGpMBjhCEhUd5C9myM5sKtYcTNz66H725wuifuujyA==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@utoo/pack-linux-x64-gnu@1.4.26':
-    resolution: {integrity: sha512-bMGCQEZLdGYa8xDtP05nbxd18Px83QBB3gMlUsS0pOs2qKA7A0RFx4Fa09ppyAxR7USbkktXVPe3UPj+nUm1Hw==}
+  '@utoo/pack-linux-x64-gnu@1.5.0':
+    resolution: {integrity: sha512-dys9SrvU4L0RBPAQ+i8P9QbBGHKHAlUcXBdlBORrJeH5XIX47bbM8Kt26ORpvySNmV4aTvJ5d6mtkayR0Yz2GA==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@utoo/pack-linux-x64-musl@1.4.26':
-    resolution: {integrity: sha512-xL1r2ilwB8zd2bbaWZsMnC3ZQVLlx+2pKU+5PSjTqXYwgWPqu6W0HV55/bNpIvei685rSym3DnS38eJW0qNCDg==}
+  '@utoo/pack-linux-x64-musl@1.5.0':
+    resolution: {integrity: sha512-LpR5lO+ebZhYI2liyXsFCEL6u54rl42voMnKxS+MlEf/FJMreeQ5XPUSWObx+YCPDdRaBjh9JkiSnaOFGMTD+A==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@utoo/pack-shared@1.4.26':
-    resolution: {integrity: sha512-+Nzb0fH/7TVSXlGOr/MkMzSIaJbtlYPKOGik9Toil0sxy8Zy2UcIARr0ujdtM2axCntacZBkd8PtjrY7V3tqqA==}
+  '@utoo/pack-shared@1.5.0':
+    resolution: {integrity: sha512-0kbGUf82T7GCaTqHzsvR8d6l2F25VZ552kZdp4+8zz0qAXydjRMW3mQrzfj6UUIFDoN1M8g+O297XO3mMJ7kGw==}
     engines: {node: '>= 20'}
 
-  '@utoo/pack-win32-x64-msvc@1.4.26':
-    resolution: {integrity: sha512-PGnnmpSHl3LVN6yWgKPuytRfwA4UF2kG+IFtFXg5GqBF81d/OQJj41pygSTg1DVK2ZvuV+QohsM3RcjmEw8oMg==}
+  '@utoo/pack-win32-x64-msvc@1.5.0':
+    resolution: {integrity: sha512-YQ8IpsQUAlVtey+6jwv2zmm+FBg9NgdidpR+Mx1o86fMY3T20o2ZWybQjVa7xwU2Sz/XqGH5e6sKKjZXSsVvZQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [win32]
 
-  '@utoo/pack@1.4.26':
-    resolution: {integrity: sha512-sUymyaN4svt08vqfrzFl6sWEE2LgnIe10TRNquNlg7/BBTCUreUp6m3zh3eTf7vfrDyC0+uFogWazNO+wNmSGA==}
+  '@utoo/pack@1.5.0':
+    resolution: {integrity: sha512-1hLRitEju/parkZdI8LUauz7tccVoNf6Dp8X63l5pJuYUlBG1xnBekryAoTMf4dbLPO4FaOEPkuAQxaLOgH1AQ==}
     engines: {node: '>= 20'}
     peerDependencies:
       less: ^4.0.0
@@ -13623,9 +13623,9 @@ snapshots:
       '@use-gesture/core': 10.3.0
       react: 19.2.7
 
-  '@utoo/pack-cli@1.4.26(postcss@8.5.19)':
+  '@utoo/pack-cli@1.5.0(postcss@8.5.19)':
     dependencies:
-      '@utoo/pack': 1.4.26(postcss@8.5.19)
+      '@utoo/pack': 1.5.0(postcss@8.5.19)
       citty: 0.1.6
     transitivePeerDependencies:
       - bufferutil
@@ -13639,39 +13639,39 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@utoo/pack-darwin-arm64@1.4.26':
+  '@utoo/pack-darwin-arm64@1.5.0':
     optional: true
 
-  '@utoo/pack-darwin-x64@1.4.26':
+  '@utoo/pack-darwin-x64@1.5.0':
     optional: true
 
-  '@utoo/pack-linux-arm64-gnu@1.4.26':
+  '@utoo/pack-linux-arm64-gnu@1.5.0':
     optional: true
 
-  '@utoo/pack-linux-arm64-musl@1.4.26':
+  '@utoo/pack-linux-arm64-musl@1.5.0':
     optional: true
 
-  '@utoo/pack-linux-x64-gnu@1.4.26':
+  '@utoo/pack-linux-x64-gnu@1.5.0':
     optional: true
 
-  '@utoo/pack-linux-x64-musl@1.4.26':
+  '@utoo/pack-linux-x64-musl@1.5.0':
     optional: true
 
-  '@utoo/pack-shared@1.4.26':
+  '@utoo/pack-shared@1.5.0':
     dependencies:
       '@babel/code-frame': 7.22.5
       picocolors: 1.1.1
 
-  '@utoo/pack-win32-x64-msvc@1.4.26':
+  '@utoo/pack-win32-x64-msvc@1.5.0':
     optional: true
 
-  '@utoo/pack@1.4.26(postcss@8.5.19)':
+  '@utoo/pack@1.5.0(postcss@8.5.19)':
     dependencies:
       '@babel/code-frame': 7.22.5
       '@hono/node-server': 1.19.14(hono@4.12.21)
       '@hono/node-ws': 1.3.1(@hono/node-server@1.19.14(hono@4.12.21))(hono@4.12.21)
       '@swc/helpers': 0.5.15
-      '@utoo/pack-shared': 1.4.26
+      '@utoo/pack-shared': 1.5.0
       domparser-rs: 0.0.7
       find-up: 4.1.0
       get-port: 5.1.1
@@ -13683,13 +13683,13 @@ snapshots:
       send: 0.17.1
       ws: 8.21.0
     optionalDependencies:
-      '@utoo/pack-darwin-arm64': 1.4.26
-      '@utoo/pack-darwin-x64': 1.4.26
-      '@utoo/pack-linux-arm64-gnu': 1.4.26
-      '@utoo/pack-linux-arm64-musl': 1.4.26
-      '@utoo/pack-linux-x64-gnu': 1.4.26
-      '@utoo/pack-linux-x64-musl': 1.4.26
-      '@utoo/pack-win32-x64-msvc': 1.4.26
+      '@utoo/pack-darwin-arm64': 1.5.0
+      '@utoo/pack-darwin-x64': 1.5.0
+      '@utoo/pack-linux-arm64-gnu': 1.5.0
+      '@utoo/pack-linux-arm64-musl': 1.5.0
+      '@utoo/pack-linux-x64-gnu': 1.5.0
+      '@utoo/pack-linux-x64-musl': 1.5.0
+      '@utoo/pack-win32-x64-msvc': 1.5.0
     transitivePeerDependencies:
       - bufferutil
       - supports-color


### PR DESCRIPTION
## Summary

- update `@utoo/pack-cli` from 1.4.26 to 1.5.0
- refresh the pnpm lockfile for the matching `@utoo/pack` platform packages

## Why

Keep the Utoo benchmark on the latest CLI release so benchmark runs exercise the current implementation.

## Impact

The benchmark suite will use Utoo 1.5.0; no benchmark configuration changes are included.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm --dir cases/react-1k build:utoo`
